### PR TITLE
'font-awesome-rails'を適用するためにbundle installを実行する

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,6 +54,8 @@ GEM
     erubis (2.7.0)
     execjs (2.7.0)
     ffi (1.11.1)
+    font-awesome-rails (4.7.0.5)
+      railties (>= 3.2, < 6.1)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     haml (5.1.1)
@@ -176,6 +178,7 @@ PLATFORMS
 DEPENDENCIES
   byebug
   coffee-rails (~> 4.2)
+  font-awesome-rails
   haml-rails
   jbuilder (~> 2.5)
   jquery-rails


### PR DESCRIPTION
# What
'font-awesome-rails'を適用するためにbundle installを実行する。

# Why
Font Awesomeアイコンをチャットグループ作成やメッセージのファイル添付のボタンに使用したいから。