### PR TITLE
ユーザー名の右にFontAwesomeアイコンを２つ追加する

### DIFF
--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -6,10 +6,10 @@
       test-user
     %ul.menu__user__icons
       %li.menu__user__icons__new-group
-        %a{href: "#"}
+        = link_to '#' do
           %i.fa.fa-edit
       %li.menu__user__icons__edit-user
-        %a{href: "#"}
+        = link_to '#' do
           %li.fa.fa-cog    
   %ul.menu__group
     %li.menu__group__list

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -2,7 +2,15 @@
   グループを作成しました
 .menu
   .menu__user
-    test-user
+    %p.menu__user__name
+      test-user
+    %ul.menu__user__icons
+      %li.menu__user__icons__new-group
+        %a{href: "#"}
+          %i.fa.fa-edit
+      %li.menu__user__icons__edit-user
+        %a{href: "#"}
+          %li.fa.fa-cog    
   %ul.menu__group
     %li.menu__group__list
       test-group


### PR DESCRIPTION
# What
ユーザー名の右にFontAwesomeアイコン（グループ作成、アカウント編集の２種）を追加する。

# Why
ユーザーに視覚的にわかりやすくグループ作成やアカウント編集を行ってほしいため。