### PR TITLE
メッセージ投稿の非同期化

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,3 +62,7 @@ gem 'font-awesome-rails'
 gem 'devise'
 gem 'carrierwave'
 gem 'mini_magick'
+
+group :production do
+  gem 'unicorn', '5.4.1'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,6 +100,7 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
+    kgio (2.11.2)
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -157,6 +158,7 @@ GEM
       method_source
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
+    raindrops (0.19.0)
     rake (12.3.2)
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
@@ -217,6 +219,9 @@ GEM
       thread_safe (~> 0.1)
     uglifier (4.1.20)
       execjs (>= 0.3.0, < 3)
+    unicorn (5.4.1)
+      kgio (~> 2.6)
+      raindrops (~> 0.7)
     warden (1.2.8)
       rack (>= 2.0.6)
     web-console (3.7.0)
@@ -256,6 +261,7 @@ DEPENDENCIES
   turbolinks (~> 5)
   tzinfo-data
   uglifier (>= 1.3.0)
+  unicorn (= 5.4.1)
   web-console (>= 3.3.0)
 
 BUNDLED WITH

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,0 +1,55 @@
+$(function() {
+  function buildHTML(message){
+    var html = `<div class="message" data="${message.id}">
+                  <div class="message-about">
+                    <div class="message-about__user">
+                      ${message.name}
+                    </div>
+                    <span class="message-about__time">
+                      ${message.created_at}
+                    </span>
+                  </div>
+                  <div class="message__message">
+                    <p class="message__message__content">
+                      ${message.content}
+                    </p>`
+                  if (message.image.url === null) {
+                    var html2 = html + `</div>
+                                </div>`
+                    return html2;
+                  } else {
+                    var html2 = html + `<img src="${message.image.url}">
+                                          </div>
+                                        </div>`
+                    return html2;
+                  }
+  }
+
+  $('#new_message').on('submit', function(e){
+    e.preventDefault();
+    var formData = new FormData(this);
+    var url = $(this).attr('action')
+    $.ajax({
+      url: url,
+      type: "POST",
+      data: formData,
+      dataType: 'json',
+      processData: false,
+      contentType: false
+    })
+
+    .done(function(data) {
+      var html = buildHTML(data);
+      $('.message-details').append(html);
+      $('.message-form__text').val('');
+      $('.hidden').val('');
+      $('.send-button').prop('disabled', false);
+      $('.message-details').animate({scrollTop: $('.message-details')[0].scrollHeight}, 'fast');
+    })
+
+    .fail(function() {
+      alert('メッセージの送信に失敗しました');
+      $('.send-button').attr('disabled', false);
+    })
+  });
+});

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -41,8 +41,7 @@ $(function() {
     .done(function(data) {
       var html = buildHTML(data);
       $('.message-details').append(html);
-      $('.message-form__text').val('');
-      $('.hidden').val('');
+      $('.message-form')[0].reset();
       $('.send-button').prop('disabled', false);
       $('.message-details').animate({scrollTop: $('.message-details')[0].scrollHeight}, 'fast');
     })

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -3,13 +3,22 @@ class MessagesController < ApplicationController
 
   def index
     @message = Message.new
+    @message.user_id = current_user.id
     @messages = @group.messages.includes(:user)
+    respond_to do |format|
+      format.html
+      format.json
+    end
   end
 
   def create
     @message = @group.messages.new(message_params)
+    @message.user_id = current_user.id
     if @message.save
-      redirect_to group_messages_path(@group), notice: ' メッセージが送信されました'
+      respond_to do |format|
+        format.html {redirect_to group_messages_path(@group), notice: 'メッセージが送信されました'}
+        format.json
+      end
     else
       @messages = @group.messages.includes(:user)
       flash.now[:alert] = 'メッセージを入力してください。'
@@ -20,7 +29,7 @@ class MessagesController < ApplicationController
   private
 
   def message_params
-    params.require(:message).permit(:content, :image).merge(user_id: current_user.id)
+    params.require(:message).permit(:content, :image, :user_id).merge(group_id: params[:group_id])
   end
 
   def set_group

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -29,7 +29,7 @@ class MessagesController < ApplicationController
   private
 
   def message_params
-    params.require(:message).permit(:content, :image, :user_id).merge(group_id: params[:group_id])
+    params.require(:message).permit(:content, :image)
   end
 
   def set_group

--- a/app/helpers/devise_helper.rb
+++ b/app/helpers/devise_helper.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module DeviseHelper
+  # Retain this method for backwards compatibility, deprecated in favour of modifying the
+  # devise/shared/error_messages partial
+  def devise_error_messages!
+    ActiveSupport::Deprecation.warn <<-DEPRECATION.strip_heredoc
+      [Devise] `DeviseHelper.devise_error_messages!`
+      is deprecated and it will be removed in the next major version.
+      To customize the errors styles please run `rails g devise:views` and modify the
+      `devise/shared/error_messages` partial.
+    DEPRECATION
+
+    return "" if resource.errors.empty?
+
+    render "devise/shared/error_messages", resource: resource
+  end
+end

--- a/app/uploaders/message_image_uploader.rb
+++ b/app/uploaders/message_image_uploader.rb
@@ -35,9 +35,9 @@ class MessageImageUploader < CarrierWave::Uploader::Base
 
   # Add a white list of extensions which are allowed to be uploaded.
   # For images you might use something like this:
-  # def extension_whitelist
-  #   %w(jpg jpeg gif png)
-  # end
+  def extension_whitelist
+    %w(jpg jpeg gif png)
+  end
 
   # Override the filename of the uploaded files:
   # Avoid using model.id or version_name here, see uploader/store.rb for details.

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,4 @@
-.message
+.message{data: "#{message.id}"}
   .message-about
     .message-about__user
       = message.user.name
@@ -8,4 +8,4 @@
     - if message.content.present?
       %p.message__message__content
         = message.content  
-    = image_tag message.image.url, class: 'message__message__image' if message.image.present?
+    = image_tag message.image, class: 'message__message__image' if message.image.present?

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,0 +1,7 @@
+json.id         @message.id
+json.content    @message.content
+json.group_id   @message.group_id
+json.user_id    @message.user_id
+json.name       @message.user.name
+json.image      @message.image
+json.created_at @message.created_at.strftime("%Y/%m/%d %H:%M")

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,7 +1,5 @@
 json.id         @message.id
 json.content    @message.content
-json.group_id   @message.group_id
-json.user_id    @message.user_id
 json.name       @message.user.name
 json.image      @message.image
 json.created_at @message.created_at.strftime("%Y/%m/%d %H:%M")

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -12,12 +12,11 @@
     = link_to 'Edit', edit_group_path(@group), class: "edit-button"
   .message-details
     = render @messages
-  .message-form
-    = form_for [@group, @message] do |f|
-      = f.hidden_field :user_id, value: "#{@message.user_id}"
-      = f.text_field :content, autofocus: true, class: 'message-form__text', placeholder: 'type a message'
-      .message-form__mask
-        = f.label :image, class: 'message-form__mask__label' do
-          = fa_icon 'picture-o', class: 'icon'
-          = f.file_field :image, class: 'hidden', style: "display:none"
-      = f.submit 'Send', class: 'send-button'
+  = form_for [@group, @message], html: {class: 'message-form'} do |f|
+    = f.hidden_field :user_id, value: "#{@message.user_id}"
+    = f.text_field :content, autofocus: true, class: 'message-form__text', placeholder: 'type a message'
+    .message-form__mask
+      = f.label :image, class: 'message-form__mask__label' do
+        = fa_icon 'picture-o', class: 'icon'
+        = f.file_field :image, class: 'hidden', style: "display:none"
+    = f.submit 'Send', class: 'send-button'

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -14,7 +14,8 @@
     = render @messages
   .message-form
     = form_for [@group, @message] do |f|
-      = f.text_field :content, class: 'message-form__text', placeholder: 'type a message'
+      = f.hidden_field :user_id, value: "#{@message.user_id}"
+      = f.text_field :content, autofocus: true, class: 'message-form__text', placeholder: 'type a message'
       .message-form__mask
         = f.label :image, class: 'message-form__mask__label' do
           = fa_icon 'picture-o', class: 'icon'

--- a/app/views/messages/index.json.jbuilder
+++ b/app/views/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.messages @massages.each do |message|
+  json.name       message.user.name
+  json.created_at message.created_at.strftime("%Y/%m/%d %H:%M")
+  json.content    message.content
+  json.image      message.image
+  json.id         message.id
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   devise_for :users
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   root 'groups#index'
-  resources :users, only: [:index, :edit, :update]
+  resources :users, only: [:index, :create, :edit, :update]
   resources :groups, only:[:new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
   end

--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -1,0 +1,55 @@
+#サーバ上でのアプリケーションコードが設置されているディレクトリを変数に入れておく
+app_path = File.expand_path('../../', __FILE__)
+
+#アプリケーションサーバの性能を決定する
+worker_processes 1
+
+#アプリケーションの設置されているディレクトリを指定
+working_directory app_path
+
+#Unicornの起動に必要なファイルの設置場所を指定
+pid "#{app_path}/tmp/pids/unicorn.pid"
+
+#ポート番号を指定
+listen 3000
+
+#エラーのログを記録するファイルを指定
+stderr_path "#{app_path}/log/unicorn.stderr.log"
+
+#通常のログを記録するファイルを指定
+stdout_path "#{app_path}/log/unicorn.stdout.log"
+
+#Railsアプリケーションの応答を待つ上限時間を設定
+timeout 60
+
+#以下は応用的な設定なので説明は割愛
+
+preload_app true
+GC.respond_to?(:copy_on_write_friendly=) && GC.copy_on_write_friendly = true
+
+check_client_connection false
+
+run_once = true
+
+before_fork do |server, worker|
+  defined?(ActiveRecord::Base) &&
+    ActiveRecord::Base.connection.disconnect!
+
+  if run_once
+    run_once = false # prevent from firing again
+  end
+
+  old_pid = "#{server.config[:pid]}.oldbin"
+  if File.exist?(old_pid) && server.pid != old_pid
+    begin
+      sig = (worker.nr + 1) >= server.worker_processes ? :QUIT : :TTOU
+      Process.kill(sig, File.read(old_pid).to_i)
+    rescue Errno::ENOENT, Errno::ESRCH => e
+      logger.error e
+    end
+  end
+end
+
+after_fork do |_server, _worker|
+  defined?(ActiveRecord::Base) && ActiveRecord::Base.establish_connection
+end


### PR DESCRIPTION
# What
チャットメッセージの投稿に非同期通信を利用する。

# Why
非同期通信を利用することで通信の負担を減らしユーザーに快適に利用してもらうため。

以下、動作のgifを貼ったURLです。
https://gyazo.com/50707a698f17ce61f6f678f5c7806ae7